### PR TITLE
레시피 스크랩 저장

### DIFF
--- a/src/main/java/likelion/hackerthon/grocering/recipe/controller/RecipeScrapController.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/controller/RecipeScrapController.java
@@ -1,0 +1,173 @@
+package likelion.hackerthon.grocering.recipe.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapListResponse;
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapRequest;
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapResponse;
+import likelion.hackerthon.grocering.recipe.service.RecipeScrapService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "레시피 스크랩(Recipe Scrap)", description = "레시피 스크랩 및 즐겨찾기 관련 API 입니다.")
+@RestController
+@RequestMapping("/api/recipe/scraps")
+@RequiredArgsConstructor
+public class RecipeScrapController {
+    
+    private final RecipeScrapService recipeScrapService;
+    
+    @Operation(summary = "레시피 스크랩", description = "AI가 추천한 레시피를 스크랩(즐겨찾기)에 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "스크랩 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 이미 스크랩한 레시피"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    public ResponseEntity<RecipeScrapResponse> scrapRecipe(
+            @Valid @RequestBody RecipeScrapRequest request,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        RecipeScrapResponse response = recipeScrapService.scrapRecipe(Long.valueOf(userId), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+    
+    @Operation(summary = "내 스크랩 레시피 목록 조회 (페이징)", description = "사용자가 스크랩한 레시피 목록을 페이징으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping
+    public ResponseEntity<RecipeScrapListResponse> getMyScrapList(
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") 
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지당 항목 수", example = "10") 
+            @RequestParam(defaultValue = "10") int size,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        RecipeScrapListResponse response = recipeScrapService.getUserScrapList(Long.valueOf(userId), page, size);
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(summary = "내 스크랩 레시피 전체 목록 조회", description = "사용자가 스크랩한 모든 레시피를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/all")
+    public ResponseEntity<List<RecipeScrapResponse>> getAllMyScrap(
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        List<RecipeScrapResponse> response = recipeScrapService.getAllUserScraps(Long.valueOf(userId));
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(summary = "스크랩 레시피 상세 조회", description = "특정 스크랩 레시피의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "403", description = "접근 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "스크랩 레시피를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/{scrapId}")
+    public ResponseEntity<RecipeScrapResponse> getScrapDetail(
+            @Parameter(description = "스크랩 ID", example = "1") 
+            @PathVariable Long scrapId,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        RecipeScrapResponse response = recipeScrapService.getScrapDetail(Long.valueOf(userId), scrapId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(summary = "스크랩 레시피 삭제", description = "스크랩한 레시피를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "403", description = "삭제 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "스크랩 레시피를 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/{scrapId}")
+    public ResponseEntity<Void> deleteScrap(
+            @Parameter(description = "스크랩 ID", example = "1") 
+            @PathVariable Long scrapId,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        recipeScrapService.deleteScrap(Long.valueOf(userId), scrapId);
+        return ResponseEntity.noContent().build();
+    }
+    
+    @Operation(summary = "식료품점별 스크랩 레시피 조회", description = "특정 식료품점 기반으로 스크랩한 레시피들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/grocery/{groceryId}")
+    public ResponseEntity<List<RecipeScrapResponse>> getScrapsByGrocery(
+            @Parameter(description = "식료품점 ID", example = "1") 
+            @PathVariable Long groceryId,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        List<RecipeScrapResponse> response = recipeScrapService.getScrapsByGrocery(Long.valueOf(userId), groceryId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(summary = "요리 유형별 스크랩 레시피 조회", description = "특정 요리 유형(한식, 중식 등)으로 스크랩한 레시피들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/cuisine/{cuisineType}")
+    public ResponseEntity<List<RecipeScrapResponse>> getScrapsByCuisineType(
+            @Parameter(description = "요리 유형", example = "한식") 
+            @PathVariable String cuisineType,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        List<RecipeScrapResponse> response = recipeScrapService.getScrapsByCuisineType(Long.valueOf(userId), cuisineType);
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(summary = "내 스크랩 개수 조회", description = "사용자가 스크랩한 레시피의 총 개수를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/count")
+    public ResponseEntity<Long> getMyScrapCount(
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        long count = recipeScrapService.getUserScrapCount(Long.valueOf(userId));
+        return ResponseEntity.ok(count);
+    }
+    
+    @Operation(summary = "레시피 스크랩 여부 확인", description = "특정 레시피가 이미 스크랩되어 있는지 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "확인 완료"),
+            @ApiResponse(responseCode = "401", description = "세션이 만료되었거나 유효하지 않음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @GetMapping("/check")
+    public ResponseEntity<Boolean> checkScrapStatus(
+            @Parameter(description = "레시피명", example = "김치찌개") 
+            @RequestParam String recipeName,
+            @Parameter(hidden = true) @SessionAttribute(name = "userId", required = true) String userId) {
+        
+        boolean isScrapped = recipeScrapService.isAlreadyScrapped(Long.valueOf(userId), recipeName);
+        return ResponseEntity.ok(isScrapped);
+    }
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapListResponse.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapListResponse.java
@@ -1,0 +1,32 @@
+package likelion.hackerthon.grocering.recipe.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "스크랩된 레시피 목록 응답")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecipeScrapListResponse {
+    
+    @Schema(description = "총 스크랩 개수", example = "15")
+    private long totalCount;
+    
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    private int currentPage;
+    
+    @Schema(description = "총 페이지 수", example = "3")
+    private int totalPages;
+    
+    @Schema(description = "페이지당 항목 수", example = "10")
+    private int pageSize;
+    
+    @Schema(description = "스크랩된 레시피 목록")
+    private List<RecipeScrapResponse> recipes;
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapRequest.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapRequest.java
@@ -1,0 +1,40 @@
+package likelion.hackerthon.grocering.recipe.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Schema(description = "레시피 스크랩 요청 정보")
+@Data
+public class RecipeScrapRequest {
+    
+    @Schema(description = "레시피명", example = "김치찌개", required = true)
+    @NotBlank(message = "레시피명은 필수입니다")
+    @Size(max = 200, message = "레시피명은 200자 이내로 입력해주세요")
+    private String recipeName;
+    
+    @Schema(description = "레시피 전체 내용 (AI 응답)", required = true)
+    @NotBlank(message = "레시피 내용은 필수입니다")
+    private String recipeContent;
+    
+    @Schema(description = "요리 종류", example = "한식")
+    @Size(max = 50, message = "요리 종류는 50자 이내로 입력해주세요")
+    private String cuisineType;
+    
+    @Schema(description = "난이도", example = "보통", allowableValues = {"쉬움", "보통", "어려움"})
+    @Size(max = 20, message = "난이도는 20자 이내로 입력해주세요")
+    private String difficulty;
+    
+    @Schema(description = "조리시간 (분 단위)", example = "30")
+    private Integer cookingTime;
+    
+    @Schema(description = "식료품점 ID", example = "1", required = true)
+    @NotNull(message = "식료품점 ID는 필수입니다")
+    private Long groceryId;
+    
+    @Schema(description = "식료품점명", example = "○○ 수입식품마트")
+    @Size(max = 100, message = "식료품점명은 100자 이내로 입력해주세요")
+    private String groceryName;
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapResponse.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/dto/RecipeScrapResponse.java
@@ -1,0 +1,44 @@
+package likelion.hackerthon.grocering.recipe.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "스크랩된 레시피 정보")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RecipeScrapResponse {
+    
+    @Schema(description = "스크랩 ID", example = "1")
+    private Long id;
+    
+    @Schema(description = "레시피명", example = "김치찌개")
+    private String recipeName;
+    
+    @Schema(description = "레시피 전체 내용")
+    private String recipeContent;
+    
+    @Schema(description = "요리 종류", example = "한식")
+    private String cuisineType;
+    
+    @Schema(description = "난이도", example = "보통")
+    private String difficulty;
+    
+    @Schema(description = "조리시간 (분 단위)", example = "30")
+    private Integer cookingTime;
+    
+    @Schema(description = "식료품점 ID", example = "1")
+    private Long groceryId;
+    
+    @Schema(description = "식료품점명", example = "○○ 수입식품마트")
+    private String groceryName;
+    
+    @Schema(description = "스크랩 등록일시", example = "2025-08-22T10:30:00")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/entity/UserRecipeScrap.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/entity/UserRecipeScrap.java
@@ -1,0 +1,51 @@
+package likelion.hackerthon.grocering.recipe.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_recipe_scraps")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserRecipeScrap {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+    
+    @Column(name = "recipe_name", nullable = false, length = 200)
+    private String recipeName;
+    
+    @Column(name = "recipe_content", columnDefinition = "TEXT")
+    private String recipeContent;
+    
+    @Column(name = "cuisine_type", length = 50)
+    private String cuisineType;
+    
+    @Column(name = "difficulty", length = 20)
+    private String difficulty;
+    
+    @Column(name = "cooking_time")
+    private Integer cookingTime;
+    
+    @Column(name = "grocery_id")
+    private Long groceryId;
+    
+    @Column(name = "grocery_name", length = 100)
+    private String groceryName;
+    
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/repository/UserRecipeScrapRepository.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/repository/UserRecipeScrapRepository.java
@@ -1,0 +1,52 @@
+package likelion.hackerthon.grocering.recipe.repository;
+
+import likelion.hackerthon.grocering.recipe.entity.UserRecipeScrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserRecipeScrapRepository extends JpaRepository<UserRecipeScrap, Long> {
+    
+    /**
+     * 사용자별 스크랩한 레시피 목록 조회 (페이징)
+     */
+    Page<UserRecipeScrap> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    
+    /**
+     * 사용자별 스크랩한 레시피 목록 조회 (전체)
+     */
+    List<UserRecipeScrap> findByUserIdOrderByCreatedAtDesc(Long userId);
+    
+    /**
+     * 특정 사용자의 특정 레시피 스크랩 존재 여부 확인
+     */
+    boolean existsByUserIdAndRecipeName(Long userId, String recipeName);
+    
+    /**
+     * 특정 사용자의 특정 레시피 스크랩 조회
+     */
+    Optional<UserRecipeScrap> findByUserIdAndRecipeName(Long userId, String recipeName);
+    
+    /**
+     * 사용자별 스크랩 개수 조회
+     */
+    long countByUserId(Long userId);
+    
+    /**
+     * 특정 식료품점 기반 스크랩 레시피 조회
+     */
+    List<UserRecipeScrap> findByUserIdAndGroceryIdOrderByCreatedAtDesc(Long userId, Long groceryId);
+    
+    /**
+     * 요리 유형별 스크랩 레시피 조회
+     */
+    @Query("SELECT u FROM UserRecipeScrap u WHERE u.userId = :userId AND u.cuisineType = :cuisineType ORDER BY u.createdAt DESC")
+    List<UserRecipeScrap> findByUserIdAndCuisineType(@Param("userId") Long userId, @Param("cuisineType") String cuisineType);
+}

--- a/src/main/java/likelion/hackerthon/grocering/recipe/service/RecipeScrapService.java
+++ b/src/main/java/likelion/hackerthon/grocering/recipe/service/RecipeScrapService.java
@@ -1,0 +1,166 @@
+package likelion.hackerthon.grocering.recipe.service;
+
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapListResponse;
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapRequest;
+import likelion.hackerthon.grocering.recipe.dto.RecipeScrapResponse;
+import likelion.hackerthon.grocering.recipe.entity.UserRecipeScrap;
+import likelion.hackerthon.grocering.recipe.repository.UserRecipeScrapRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecipeScrapService {
+    
+    private final UserRecipeScrapRepository recipeScrapRepository;
+    
+    /**
+     * 레시피 스크랩 저장
+     */
+    @Transactional
+    public RecipeScrapResponse scrapRecipe(Long userId, RecipeScrapRequest request) {
+        // 중복 스크랩 체크
+        if (recipeScrapRepository.existsByUserIdAndRecipeName(userId, request.getRecipeName())) {
+            throw new RuntimeException("이미 스크랩한 레시피입니다: " + request.getRecipeName());
+        }
+        
+        UserRecipeScrap scrap = UserRecipeScrap.builder()
+                .userId(userId)
+                .recipeName(request.getRecipeName())
+                .recipeContent(request.getRecipeContent())
+                .cuisineType(request.getCuisineType())
+                .difficulty(request.getDifficulty())
+                .cookingTime(request.getCookingTime())
+                .groceryId(request.getGroceryId())
+                .groceryName(request.getGroceryName())
+                .build();
+        
+        UserRecipeScrap savedScrap = recipeScrapRepository.save(scrap);
+        log.info("레시피 스크랩 저장 완료 - 사용자: {}, 레시피: {}", userId, request.getRecipeName());
+        
+        return convertToResponse(savedScrap);
+    }
+    
+    /**
+     * 사용자별 스크랩 레시피 목록 조회 (페이징)
+     */
+    public RecipeScrapListResponse getUserScrapList(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<UserRecipeScrap> scrapPage = recipeScrapRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+        
+        List<RecipeScrapResponse> recipes = scrapPage.getContent().stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+        
+        return RecipeScrapListResponse.builder()
+                .totalCount(scrapPage.getTotalElements())
+                .currentPage(scrapPage.getNumber())
+                .totalPages(scrapPage.getTotalPages())
+                .pageSize(scrapPage.getSize())
+                .recipes(recipes)
+                .build();
+    }
+    
+    /**
+     * 사용자별 스크랩 레시피 전체 목록 조회
+     */
+    public List<RecipeScrapResponse> getAllUserScraps(Long userId) {
+        List<UserRecipeScrap> scraps = recipeScrapRepository.findByUserIdOrderByCreatedAtDesc(userId);
+        return scraps.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 특정 스크랩 레시피 상세 조회
+     */
+    public RecipeScrapResponse getScrapDetail(Long userId, Long scrapId) {
+        UserRecipeScrap scrap = recipeScrapRepository.findById(scrapId)
+                .orElseThrow(() -> new RuntimeException("스크랩 레시피를 찾을 수 없습니다: " + scrapId));
+        
+        // 본인 스크랩인지 확인
+        if (!scrap.getUserId().equals(userId)) {
+            throw new RuntimeException("접근 권한이 없습니다.");
+        }
+        
+        return convertToResponse(scrap);
+    }
+    
+    /**
+     * 스크랩 레시피 삭제
+     */
+    @Transactional
+    public void deleteScrap(Long userId, Long scrapId) {
+        UserRecipeScrap scrap = recipeScrapRepository.findById(scrapId)
+                .orElseThrow(() -> new RuntimeException("스크랩 레시피를 찾을 수 없습니다: " + scrapId));
+        
+        // 본인 스크랩인지 확인
+        if (!scrap.getUserId().equals(userId)) {
+            throw new RuntimeException("삭제 권한이 없습니다.");
+        }
+        
+        recipeScrapRepository.delete(scrap);
+        log.info("레시피 스크랩 삭제 완료 - 사용자: {}, 스크랩 ID: {}", userId, scrapId);
+    }
+    
+    /**
+     * 특정 식료품점 기반 스크랩 레시피 조회
+     */
+    public List<RecipeScrapResponse> getScrapsByGrocery(Long userId, Long groceryId) {
+        List<UserRecipeScrap> scraps = recipeScrapRepository.findByUserIdAndGroceryIdOrderByCreatedAtDesc(userId, groceryId);
+        return scraps.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 요리 유형별 스크랩 레시피 조회
+     */
+    public List<RecipeScrapResponse> getScrapsByCuisineType(Long userId, String cuisineType) {
+        List<UserRecipeScrap> scraps = recipeScrapRepository.findByUserIdAndCuisineType(userId, cuisineType);
+        return scraps.stream()
+                .map(this::convertToResponse)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 사용자 스크랩 개수 조회
+     */
+    public long getUserScrapCount(Long userId) {
+        return recipeScrapRepository.countByUserId(userId);
+    }
+    
+    /**
+     * 스크랩 중복 체크
+     */
+    public boolean isAlreadyScrapped(Long userId, String recipeName) {
+        return recipeScrapRepository.existsByUserIdAndRecipeName(userId, recipeName);
+    }
+    
+    /**
+     * Entity를 Response DTO로 변환
+     */
+    private RecipeScrapResponse convertToResponse(UserRecipeScrap scrap) {
+        return RecipeScrapResponse.builder()
+                .id(scrap.getId())
+                .recipeName(scrap.getRecipeName())
+                .recipeContent(scrap.getRecipeContent())
+                .cuisineType(scrap.getCuisineType())
+                .difficulty(scrap.getDifficulty())
+                .cookingTime(scrap.getCookingTime())
+                .groceryId(scrap.getGroceryId())
+                .groceryName(scrap.getGroceryName())
+                .createdAt(scrap.getCreatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목
레시피 스크랩 기능

---

## 📝 변경사항
Entity & Repository
  - UserRecipeScrap 엔티티 추가 (사용자 레시피 스크랩 정보)
  - UserRecipeScrapRepository 추가 (커스텀 쿼리 메서드 포함)

Service & Controller
  - RecipeScrapService 구현 (비즈니스 로직 처리)
  - RecipeScrapController 추가 (9개 REST API 엔드포인트)

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추가 설명이 필요하다면 여기에 적어주세요.