### PR TITLE
식료품점 상품 API

### DIFF
--- a/src/main/java/likelion/hackerthon/grocering/grocery/controller/ProductController.java
+++ b/src/main/java/likelion/hackerthon/grocering/grocery/controller/ProductController.java
@@ -3,12 +3,11 @@ package likelion.hackerthon.grocering.grocery.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import likelion.hackerthon.grocering.grocery.dto.GroceryProductsResponse;
 import likelion.hackerthon.grocering.grocery.dto.SearchedGrocery;
 import likelion.hackerthon.grocering.grocery.service.ProductService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,5 +22,12 @@ public class ProductController {
     @GetMapping("/grocery-list")
     public List<SearchedGrocery> findGroceryByProductName(@RequestParam String productName) {
         return productService.getGroceryListByProductName(productName);
+    }
+
+    @Operation(summary = "식료품점별 상품 목록 조회", description = "특정 식료품점의 모든 상품을 조회하는 API입니다. AI 추천을 위한 재료 목록을 제공합니다.")
+    @Parameter(name = "groceryId", description = "식료품점 ID")
+    @GetMapping("/api/grocery/{groceryId}/products")
+    public GroceryProductsResponse getProductsByGroceryId(@PathVariable Long groceryId) {
+        return productService.getProductsByGroceryId(groceryId);
     }
 }

--- a/src/main/java/likelion/hackerthon/grocering/grocery/dto/GroceryProductsResponse.java
+++ b/src/main/java/likelion/hackerthon/grocering/grocery/dto/GroceryProductsResponse.java
@@ -1,0 +1,16 @@
+package likelion.hackerthon.grocering.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Schema(description = "식료품점의 상품 목록 정보")
+public record GroceryProductsResponse(@Schema(description = "식료품점 ID") Long groceryId,
+                                      @Schema(description = "식료품점 이름") String groceryName,
+                                      @Schema(description = "주소", example = "안산시 상록구 사동") String shotAddress,
+                                      @Schema(description = "원산지", example = "인도") String country,
+                                      @Schema(description = "오픈 시간") LocalTime openTime,
+                                      @Schema(description = "마감 시간") LocalTime closeTime,
+                                      @Schema(description = "상품 목록") List<ProductResponse> products) {
+}

--- a/src/main/java/likelion/hackerthon/grocering/grocery/dto/ProductResponse.java
+++ b/src/main/java/likelion/hackerthon/grocering/grocery/dto/ProductResponse.java
@@ -1,0 +1,9 @@
+package likelion.hackerthon.grocering.grocery.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "상품 정보")
+public record ProductResponse(@Schema(description = "상품 ID") Long id,
+                              @Schema(description = "상품 이름") String name,
+                              @Schema(description = "상품 이미지 URL") String imageUrl) {
+}

--- a/src/main/java/likelion/hackerthon/grocering/grocery/repository/ProductRepository.java
+++ b/src/main/java/likelion/hackerthon/grocering/grocery/repository/ProductRepository.java
@@ -3,5 +3,8 @@ package likelion.hackerthon.grocering.grocery.repository;
 import likelion.hackerthon.grocering.grocery.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    List<Product> findByGroceryId(Long groceryId);
 }

--- a/src/main/java/likelion/hackerthon/grocering/grocery/service/ProductService.java
+++ b/src/main/java/likelion/hackerthon/grocering/grocery/service/ProductService.java
@@ -1,6 +1,10 @@
 package likelion.hackerthon.grocering.grocery.service;
 
+import likelion.hackerthon.grocering.grocery.dto.GroceryProductsResponse;
+import likelion.hackerthon.grocering.grocery.dto.ProductResponse;
 import likelion.hackerthon.grocering.grocery.dto.SearchedGrocery;
+import likelion.hackerthon.grocering.grocery.entity.Grocery;
+import likelion.hackerthon.grocering.grocery.entity.Product;
 import likelion.hackerthon.grocering.grocery.repository.GroceryRepository;
 import likelion.hackerthon.grocering.grocery.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -18,5 +23,30 @@ public class ProductService {
 
     public List<SearchedGrocery> getGroceryListByProductName(String productName) {
         return groceryRepository.findGroceriesByProductName(productName);
+    }
+
+    public GroceryProductsResponse getProductsByGroceryId(Long groceryId) {
+        Grocery grocery = groceryRepository.findById(groceryId)
+                .orElseThrow(() -> new IllegalArgumentException("식료품점을 찾을 수 없습니다. ID: " + groceryId));
+
+        List<Product> products = productRepository.findByGroceryId(groceryId);
+        
+        List<ProductResponse> productResponses = products.stream()
+                .map(product -> new ProductResponse(
+                        product.getId(),
+                        product.getName(),
+                        product.getImageUrl()
+                ))
+                .collect(Collectors.toList());
+
+        return new GroceryProductsResponse(
+                grocery.getId(),
+                grocery.getName(),
+                grocery.getShotAddress(),
+                grocery.getCountry(),
+                grocery.getOpenTime(),
+                grocery.getCloseTime(),
+                productResponses
+        );
     }
 }


### PR DESCRIPTION
## 📌 식료품점 상품 API
---

## 📝 변경사항
Repository
  - ProductRepository`에 findByGroceryId() 메서드 추가
  -
Service & Controller
  - ProductService에 getProductsByGroceryId()메서드 구현
  - ProductController에 새로운 GET 엔드포인트 추가

DTOs
  - ProductResponse DTO 추가 (상품 기본 정보)
  - GroceryProductsResponse DTO 추가 (식료품점 + 상품 목록 통합 정보)

---

## 🔍 테스트 방법
- 예: Postman으로 /login 엔드포인트에 POST 요청 보내기

---

## 💬 기타 참고사항
- 추후 에러 핸들링 개선?